### PR TITLE
Go to beginning of buffer after gh-md-convert-region

### DIFF
--- a/gh-md.el
+++ b/gh-md.el
@@ -143,6 +143,7 @@ EXPORT writes a file."
                             (shr-render-region (point-min) (point-max))
                             (when (require 'eww nil 'noerror)
                               (eww-mode))
+                            (goto-char (point-min))
                             (display-buffer (current-buffer)))))))))))
 
 ;;;###autoload


### PR DESCRIPTION
Hi,

This PR puts the point at the beginning of the rendered buffer, the current behavior put the point at the end which is unexpected.

Cheers,
syl20bnr
