### PR TITLE
doc: Adds configuration note for possible github API error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gh-md - Render markdown using the Github api
 
 *Author:* Mario Rodas <marsam@users.noreply.github.com><br>
-*Version:* 0.1<br>
+*Version:* 0.1.1<br>
 
 [![Travis build status](https://travis-ci.org/emacs-pe/gh-md.el.png?branch=master)](https://travis-ci.org/emacs-pe/gh-md.el)
 
@@ -15,6 +15,16 @@ preview of the markdown content of a buffer.
 
 ![gh-md.el screenshot](screenshot.png)
 
+### Note
+
+If you get an error on the **Messages** buffer similar to
+`peculiar error: "connect" host, "api.github.com" :service,443`,
+then you might need to run this on your terminal:
+
+```
+git config --global --unset http.proxy
+git config --global --unset https.proxy
+```
 
 ---
 Converted from `gh-md.el` by [*el2markdown*](https://github.com/Lindydancer/el2markdown).

--- a/gh-md.el
+++ b/gh-md.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/emacs-pe/gh-md.el
 ;; Keywords: convenience
 ;; Version: 0.1.1
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -37,6 +37,17 @@
 ;; preview of the markdown content of a buffer.
 ;;
 ;; ![gh-md.el screenshot](screenshot.png)
+;;
+;; Note:
+;;
+;; If you get an error on the **Messages** buffer similar to
+;; `peculiar error: "connect" host, "api.github.com" :service,443`,
+;; then you might need to run this on your terminal:
+;;
+;; ```
+;; git config --global --unset http.proxy
+;; git config --global --unset https.proxy
+;; ```
 
 ;;; Code:
 (eval-when-compile


### PR DESCRIPTION
**doc:** Added a short note about git configuration in order to use github API if user is prompted with error on ** Messages ** buffer (as discussed here: https://github.com/emacsorphanage/gh-md/issues/7)

Aims to solve  `peculiar error: "connect" host, "api.github.com" :service,443` error.

